### PR TITLE
거래소 API 연동 및 계정 관리 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,14 @@ dependencies {
     
     // MockK for Kotlin mocking
     testImplementation("io.mockk:mockk:1.13.12")
+
+    // JWT for Upbit API authentication
+    implementation("io.jsonwebtoken:jjwt-api:0.12.3")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
+
+    // WebFlux for reactive HTTP client
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
 }
 
 kotlin {

--- a/src/main/kotlin/me/onetwo/aiautotrade/AiAutoTradeApplication.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/AiAutoTradeApplication.kt
@@ -1,9 +1,11 @@
 package me.onetwo.aiautotrade
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
+@EnableConfigurationProperties
 class AiAutoTradeApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/me/onetwo/aiautotrade/common/dto/AccountInfo.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/common/dto/AccountInfo.kt
@@ -1,0 +1,29 @@
+package me.onetwo.aiautotrade.common.dto
+
+import java.math.BigDecimal
+
+/**
+ * 거래소 계정 정보
+ *
+ * @property balances 보유 자산 목록
+ * @property totalBalance 총 자산 가치 (KRW 기준)
+ */
+data class AccountInfo(
+    val balances: List<Balance>,
+    val totalBalance: BigDecimal
+)
+
+/**
+ * 보유 자산 정보
+ *
+ * @property currency 통화 코드 (예: KRW, BTC, ETH)
+ * @property balance 보유 수량
+ * @property locked 주문 중으로 묶여있는 수량
+ * @property avgBuyPrice 평균 매수 가격
+ */
+data class Balance(
+    val currency: String,
+    val balance: BigDecimal,
+    val locked: BigDecimal,
+    val avgBuyPrice: BigDecimal? = null
+)

--- a/src/main/kotlin/me/onetwo/aiautotrade/common/dto/ApiKeyInfo.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/common/dto/ApiKeyInfo.kt
@@ -1,0 +1,24 @@
+package me.onetwo.aiautotrade.common.dto
+
+import java.time.LocalDateTime
+
+/**
+ * API 키 정보
+ *
+ * @property id API 키 ID
+ * @property userId 사용자 ID
+ * @property exchangeName 거래소 이름 (예: upbit, binance)
+ * @property accessKey Access Key (암호화됨)
+ * @property secretKey Secret Key (암호화됨)
+ * @property createdAt 생성 시각
+ * @property updatedAt 수정 시각
+ */
+data class ApiKeyInfo(
+    val id: Long? = null,
+    val userId: Long,
+    val exchangeName: String,
+    val accessKey: String,
+    val secretKey: String,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val updatedAt: LocalDateTime = LocalDateTime.now()
+)

--- a/src/main/kotlin/me/onetwo/aiautotrade/common/dto/MarketPrice.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/common/dto/MarketPrice.kt
@@ -1,0 +1,29 @@
+package me.onetwo.aiautotrade.common.dto
+
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+/**
+ * 시장 가격 정보
+ *
+ * @property market 마켓 코드
+ * @property tradePrice 현재가
+ * @property highPrice 고가
+ * @property lowPrice 저가
+ * @property openPrice 시가
+ * @property prevClosingPrice 전일 종가
+ * @property changeRate 변화율
+ * @property accTradeVolume24h 24시간 누적 거래량
+ * @property timestamp 시각
+ */
+data class MarketPrice(
+    val market: String,
+    val tradePrice: BigDecimal,
+    val highPrice: BigDecimal,
+    val lowPrice: BigDecimal,
+    val openPrice: BigDecimal,
+    val prevClosingPrice: BigDecimal,
+    val changeRate: BigDecimal,
+    val accTradeVolume24h: BigDecimal,
+    val timestamp: LocalDateTime
+)

--- a/src/main/kotlin/me/onetwo/aiautotrade/common/dto/OrderRequest.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/common/dto/OrderRequest.kt
@@ -1,0 +1,22 @@
+package me.onetwo.aiautotrade.common.dto
+
+import me.onetwo.aiautotrade.common.enums.OrderSide
+import me.onetwo.aiautotrade.common.enums.OrderType
+import java.math.BigDecimal
+
+/**
+ * 주문 요청 정보
+ *
+ * @property market 마켓 코드 (예: KRW-BTC)
+ * @property side 주문 종류 (매수/매도)
+ * @property orderType 주문 타입 (지정가/시장가)
+ * @property price 주문 가격 (지정가 주문 시)
+ * @property volume 주문 수량
+ */
+data class OrderRequest(
+    val market: String,
+    val side: OrderSide,
+    val orderType: OrderType,
+    val price: BigDecimal? = null,
+    val volume: BigDecimal? = null
+)

--- a/src/main/kotlin/me/onetwo/aiautotrade/common/dto/OrderResult.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/common/dto/OrderResult.kt
@@ -1,0 +1,34 @@
+package me.onetwo.aiautotrade.common.dto
+
+import me.onetwo.aiautotrade.common.enums.OrderSide
+import me.onetwo.aiautotrade.common.enums.OrderState
+import me.onetwo.aiautotrade.common.enums.OrderType
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+/**
+ * 주문 결과 정보
+ *
+ * @property orderId 주문 고유 ID
+ * @property market 마켓 코드
+ * @property side 주문 종류
+ * @property orderType 주문 타입
+ * @property price 주문 가격
+ * @property volume 주문 수량
+ * @property executedVolume 체결된 수량
+ * @property remainingVolume 미체결 수량
+ * @property state 주문 상태
+ * @property createdAt 주문 생성 시각
+ */
+data class OrderResult(
+    val orderId: String,
+    val market: String,
+    val side: OrderSide,
+    val orderType: OrderType,
+    val price: BigDecimal?,
+    val volume: BigDecimal,
+    val executedVolume: BigDecimal,
+    val remainingVolume: BigDecimal,
+    val state: OrderState,
+    val createdAt: LocalDateTime
+)

--- a/src/main/kotlin/me/onetwo/aiautotrade/common/enums/OrderSide.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/common/enums/OrderSide.kt
@@ -1,0 +1,12 @@
+package me.onetwo.aiautotrade.common.enums
+
+/**
+ * 주문 종류
+ */
+enum class OrderSide {
+    /** 매수 */
+    BID,
+
+    /** 매도 */
+    ASK
+}

--- a/src/main/kotlin/me/onetwo/aiautotrade/common/enums/OrderState.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/common/enums/OrderState.kt
@@ -1,0 +1,18 @@
+package me.onetwo.aiautotrade.common.enums
+
+/**
+ * 주문 상태
+ */
+enum class OrderState {
+    /** 체결 대기 */
+    WAIT,
+
+    /** 예약 주문 대기 */
+    WATCH,
+
+    /** 체결 완료 */
+    DONE,
+
+    /** 주문 취소 */
+    CANCEL
+}

--- a/src/main/kotlin/me/onetwo/aiautotrade/common/enums/OrderType.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/common/enums/OrderType.kt
@@ -1,0 +1,15 @@
+package me.onetwo.aiautotrade.common.enums
+
+/**
+ * 주문 타입
+ */
+enum class OrderType {
+    /** 지정가 주문 */
+    LIMIT,
+
+    /** 시장가 주문 (매수) */
+    PRICE,
+
+    /** 시장가 주문 (매도) */
+    MARKET
+}

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/ApiKeyService.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/ApiKeyService.kt
@@ -1,0 +1,66 @@
+package me.onetwo.aiautotrade.infrastructure.exchange
+
+import me.onetwo.aiautotrade.common.dto.ApiKeyInfo
+
+/**
+ * API 키 관리 서비스 인터페이스
+ */
+interface ApiKeyService {
+
+    /**
+     * API 키를 저장합니다.
+     *
+     * @param userId 사용자 ID
+     * @param exchangeName 거래소 이름
+     * @param accessKey Access Key (평문)
+     * @param secretKey Secret Key (평문)
+     * @return 저장된 API 키 정보
+     */
+    fun saveApiKey(
+        userId: Long,
+        exchangeName: String,
+        accessKey: String,
+        secretKey: String
+    ): ApiKeyInfo
+
+    /**
+     * 사용자의 특정 거래소 API 키를 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @param exchangeName 거래소 이름
+     * @return API 키 정보 (복호화됨), 없으면 null
+     */
+    fun getApiKey(userId: Long, exchangeName: String): ApiKeyInfo?
+
+    /**
+     * 사용자의 모든 API 키를 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @return API 키 목록 (복호화됨)
+     */
+    fun getAllApiKeys(userId: Long): List<ApiKeyInfo>
+
+    /**
+     * API 키를 삭제합니다.
+     *
+     * @param userId 사용자 ID
+     * @param exchangeName 거래소 이름
+     */
+    fun deleteApiKey(userId: Long, exchangeName: String)
+
+    /**
+     * API 키를 업데이트합니다.
+     *
+     * @param userId 사용자 ID
+     * @param exchangeName 거래소 이름
+     * @param accessKey 새로운 Access Key (평문)
+     * @param secretKey 새로운 Secret Key (평문)
+     * @return 업데이트된 API 키 정보
+     */
+    fun updateApiKey(
+        userId: Long,
+        exchangeName: String,
+        accessKey: String,
+        secretKey: String
+    ): ApiKeyInfo
+}

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/DefaultApiKeyService.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/DefaultApiKeyService.kt
@@ -1,0 +1,129 @@
+package me.onetwo.aiautotrade.infrastructure.exchange
+
+import me.onetwo.aiautotrade.common.dto.ApiKeyInfo
+import me.onetwo.aiautotrade.infrastructure.security.EncryptionService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * API 키 관리 서비스 구현체
+ *
+ * API 키를 암호화하여 저장하고 관리합니다.
+ * 현재는 메모리에 저장하며, 추후 데이터베이스 연동 시 Repository로 대체 가능합니다.
+ */
+@Service
+class DefaultApiKeyService(
+    private val encryptionService: EncryptionService
+) : ApiKeyService {
+
+    private val logger = LoggerFactory.getLogger(DefaultApiKeyService::class.java)
+
+    // 임시 메모리 저장소 (추후 데이터베이스로 대체)
+    private val apiKeyStorage = ConcurrentHashMap<String, ApiKeyInfo>()
+    private val idGenerator = AtomicLong(1)
+
+    override fun saveApiKey(
+        userId: Long,
+        exchangeName: String,
+        accessKey: String,
+        secretKey: String
+    ): ApiKeyInfo {
+        logger.info("Saving API key for user: $userId, exchange: $exchangeName")
+
+        val encryptedAccessKey = encryptionService.encrypt(accessKey)
+        val encryptedSecretKey = encryptionService.encrypt(secretKey)
+
+        val apiKeyInfo = ApiKeyInfo(
+            id = idGenerator.getAndIncrement(),
+            userId = userId,
+            exchangeName = exchangeName,
+            accessKey = encryptedAccessKey,
+            secretKey = encryptedSecretKey,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        )
+
+        val key = generateKey(userId, exchangeName)
+        apiKeyStorage[key] = apiKeyInfo
+
+        logger.info("API key saved successfully for user: $userId, exchange: $exchangeName")
+        return apiKeyInfo.copy(
+            accessKey = accessKey,
+            secretKey = secretKey
+        )
+    }
+
+    override fun getApiKey(userId: Long, exchangeName: String): ApiKeyInfo? {
+        logger.debug("Retrieving API key for user: $userId, exchange: $exchangeName")
+
+        val key = generateKey(userId, exchangeName)
+        val apiKeyInfo = apiKeyStorage[key] ?: return null
+
+        return apiKeyInfo.copy(
+            accessKey = encryptionService.decrypt(apiKeyInfo.accessKey),
+            secretKey = encryptionService.decrypt(apiKeyInfo.secretKey)
+        )
+    }
+
+    override fun getAllApiKeys(userId: Long): List<ApiKeyInfo> {
+        logger.debug("Retrieving all API keys for user: $userId")
+
+        return apiKeyStorage.values
+            .filter { it.userId == userId }
+            .map { apiKeyInfo ->
+                apiKeyInfo.copy(
+                    accessKey = encryptionService.decrypt(apiKeyInfo.accessKey),
+                    secretKey = encryptionService.decrypt(apiKeyInfo.secretKey)
+                )
+            }
+    }
+
+    override fun deleteApiKey(userId: Long, exchangeName: String) {
+        logger.info("Deleting API key for user: $userId, exchange: $exchangeName")
+
+        val key = generateKey(userId, exchangeName)
+        apiKeyStorage.remove(key)
+
+        logger.info("API key deleted successfully for user: $userId, exchange: $exchangeName")
+    }
+
+    override fun updateApiKey(
+        userId: Long,
+        exchangeName: String,
+        accessKey: String,
+        secretKey: String
+    ): ApiKeyInfo {
+        logger.info("Updating API key for user: $userId, exchange: $exchangeName")
+
+        val key = generateKey(userId, exchangeName)
+        val existingApiKey = apiKeyStorage[key]
+            ?: throw IllegalArgumentException("API key not found for user: $userId, exchange: $exchangeName")
+
+        val encryptedAccessKey = encryptionService.encrypt(accessKey)
+        val encryptedSecretKey = encryptionService.encrypt(secretKey)
+
+        val updatedApiKeyInfo = existingApiKey.copy(
+            accessKey = encryptedAccessKey,
+            secretKey = encryptedSecretKey,
+            updatedAt = LocalDateTime.now()
+        )
+
+        apiKeyStorage[key] = updatedApiKeyInfo
+
+        logger.info("API key updated successfully for user: $userId, exchange: $exchangeName")
+        return updatedApiKeyInfo.copy(
+            accessKey = accessKey,
+            secretKey = secretKey
+        )
+    }
+
+    /**
+     * 저장소 키 생성
+     */
+    private fun generateKey(userId: Long, exchangeName: String): String {
+        return "$userId:$exchangeName"
+    }
+}

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/DefaultExchangeService.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/DefaultExchangeService.kt
@@ -1,0 +1,129 @@
+package me.onetwo.aiautotrade.infrastructure.exchange
+
+import me.onetwo.aiautotrade.common.dto.AccountInfo
+import me.onetwo.aiautotrade.common.dto.MarketPrice
+import me.onetwo.aiautotrade.common.dto.OrderRequest
+import me.onetwo.aiautotrade.common.dto.OrderResult
+import me.onetwo.aiautotrade.common.enums.OrderSide
+import me.onetwo.aiautotrade.common.enums.OrderType
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.util.concurrent.CompletableFuture
+import javax.annotation.PostConstruct
+import javax.annotation.PreDestroy
+
+/**
+ * Exchange 서비스 구현체
+ *
+ * 거래소와의 모든 상호작용을 담당합니다.
+ * Provider 패턴을 사용하여 다양한 거래소를 지원합니다.
+ *
+ * @property exchangeProvider 거래소 제공업체 (업비트, 바이낸스 등)
+ */
+@Service
+class DefaultExchangeService(
+    private val exchangeProvider: ExchangeProvider
+) : ExchangeService {
+
+    private val logger = LoggerFactory.getLogger(DefaultExchangeService::class.java)
+
+    @PostConstruct
+    fun init() {
+        exchangeProvider.initialize()
+        logger.info("Exchange Service initialized with provider: {}", exchangeProvider.getProviderName())
+    }
+
+    @PreDestroy
+    fun destroy() {
+        exchangeProvider.shutdown()
+        logger.info("Exchange Service shutdown completed")
+    }
+
+    override fun getAccountInfo(): CompletableFuture<AccountInfo> {
+        logger.info("Fetching account info from {}", exchangeProvider.getProviderName())
+        return exchangeProvider.getAccountInfo()
+    }
+
+    override fun getMarketPrice(market: String): CompletableFuture<MarketPrice> {
+        logger.info("Fetching market price for {} from {}", market, exchangeProvider.getProviderName())
+        return exchangeProvider.getMarketPrice(market)
+    }
+
+    override fun buy(
+        market: String,
+        price: BigDecimal?,
+        volume: BigDecimal?
+    ): CompletableFuture<OrderResult> {
+        val orderType = determineOrderType(OrderSide.BID, price, volume)
+        val orderRequest = OrderRequest(
+            market = market,
+            side = OrderSide.BID,
+            orderType = orderType,
+            price = price,
+            volume = volume
+        )
+
+        logger.info("Placing buy order for {} with type {}", market, orderType)
+        return exchangeProvider.placeOrder(orderRequest)
+    }
+
+    override fun sell(
+        market: String,
+        price: BigDecimal?,
+        volume: BigDecimal?
+    ): CompletableFuture<OrderResult> {
+        val orderType = determineOrderType(OrderSide.ASK, price, volume)
+        val orderRequest = OrderRequest(
+            market = market,
+            side = OrderSide.ASK,
+            orderType = orderType,
+            price = price,
+            volume = volume
+        )
+
+        logger.info("Placing sell order for {} with type {}", market, orderType)
+        return exchangeProvider.placeOrder(orderRequest)
+    }
+
+    override fun cancelOrder(orderId: String): CompletableFuture<OrderResult> {
+        logger.info("Cancelling order: {}", orderId)
+        return exchangeProvider.cancelOrder(orderId)
+    }
+
+    override fun getOrderStatus(orderId: String): CompletableFuture<OrderResult> {
+        logger.info("Fetching order status: {}", orderId)
+        return exchangeProvider.getOrder(orderId)
+    }
+
+    /**
+     * 주문 타입 결정
+     *
+     * 가격과 수량 정보를 바탕으로 적절한 주문 타입을 결정합니다.
+     *
+     * @param side 주문 종류 (매수/매도)
+     * @param price 주문 가격
+     * @param volume 주문 수량
+     * @return 주문 타입
+     */
+    private fun determineOrderType(
+        side: OrderSide,
+        price: BigDecimal?,
+        volume: BigDecimal?
+    ): OrderType {
+        return when {
+            // 지정가 주문: 가격과 수량이 모두 지정된 경우
+            price != null && volume != null -> OrderType.LIMIT
+
+            // 시장가 매수: 매수이고 가격만 지정된 경우 (총 매수 금액)
+            side == OrderSide.BID && price != null -> OrderType.PRICE
+
+            // 시장가 매도: 매도이고 수량만 지정된 경우
+            side == OrderSide.ASK && volume != null -> OrderType.MARKET
+
+            else -> throw IllegalArgumentException(
+                "Invalid order parameters: side=$side, price=$price, volume=$volume"
+            )
+        }
+    }
+}

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/ExchangeProvider.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/ExchangeProvider.kt
@@ -1,0 +1,81 @@
+package me.onetwo.aiautotrade.infrastructure.exchange
+
+import me.onetwo.aiautotrade.common.dto.AccountInfo
+import me.onetwo.aiautotrade.common.dto.MarketPrice
+import me.onetwo.aiautotrade.common.dto.OrderRequest
+import me.onetwo.aiautotrade.common.dto.OrderResult
+import java.util.concurrent.CompletableFuture
+
+/**
+ * 거래소 제공업체 인터페이스
+ *
+ * 다양한 거래소(업비트, 바이낸스, 빗썸 등)를 추상화합니다.
+ * 새로운 거래소를 추가할 때는 이 인터페이스를 구현하면 됩니다.
+ */
+interface ExchangeProvider {
+
+    /**
+     * 거래소 제공업체의 이름을 반환합니다.
+     *
+     * @return 제공업체 이름 (예: "upbit", "binance", "bithumb")
+     */
+    fun getProviderName(): String
+
+    /**
+     * 거래소 제공업체가 사용 가능한 상태인지 확인합니다.
+     *
+     * @return 사용 가능하면 true, 그렇지 않으면 false
+     */
+    fun isAvailable(): Boolean
+
+    /**
+     * 계정 정보를 조회합니다.
+     *
+     * @return 보유 자산 및 잔고 정보
+     */
+    fun getAccountInfo(): CompletableFuture<AccountInfo>
+
+    /**
+     * 특정 마켓의 현재 가격 정보를 조회합니다.
+     *
+     * @param market 마켓 코드 (예: KRW-BTC)
+     * @return 시장 가격 정보
+     */
+    fun getMarketPrice(market: String): CompletableFuture<MarketPrice>
+
+    /**
+     * 주문을 실행합니다.
+     *
+     * @param orderRequest 주문 요청 정보
+     * @return 주문 결과
+     */
+    fun placeOrder(orderRequest: OrderRequest): CompletableFuture<OrderResult>
+
+    /**
+     * 주문을 취소합니다.
+     *
+     * @param orderId 주문 ID
+     * @return 취소된 주문 정보
+     */
+    fun cancelOrder(orderId: String): CompletableFuture<OrderResult>
+
+    /**
+     * 주문 상태를 조회합니다.
+     *
+     * @param orderId 주문 ID
+     * @return 주문 정보
+     */
+    fun getOrder(orderId: String): CompletableFuture<OrderResult>
+
+    /**
+     * 제공업체별 초기화 작업을 수행합니다.
+     * 인증, 연결 설정 등의 작업을 여기서 처리합니다.
+     */
+    fun initialize()
+
+    /**
+     * 제공업체별 정리 작업을 수행합니다.
+     * 연결 해제, 리소스 정리 등의 작업을 여기서 처리합니다.
+     */
+    fun shutdown()
+}

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/ExchangeService.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/ExchangeService.kt
@@ -3,6 +3,7 @@ package me.onetwo.aiautotrade.infrastructure.exchange
 import me.onetwo.aiautotrade.common.dto.AccountInfo
 import me.onetwo.aiautotrade.common.dto.MarketPrice
 import me.onetwo.aiautotrade.common.dto.OrderResult
+import java.math.BigDecimal
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -35,7 +36,7 @@ interface ExchangeService {
      * @param volume 주문 수량
      * @return 주문 결과
      */
-    fun buy(market: String, price: java.math.BigDecimal?, volume: java.math.BigDecimal?): CompletableFuture<OrderResult>
+    fun buy(market: String, price: BigDecimal?, volume: BigDecimal?): CompletableFuture<OrderResult>
 
     /**
      * 매도 주문을 실행합니다.
@@ -45,7 +46,7 @@ interface ExchangeService {
      * @param volume 주문 수량
      * @return 주문 결과
      */
-    fun sell(market: String, price: java.math.BigDecimal?, volume: java.math.BigDecimal?): CompletableFuture<OrderResult>
+    fun sell(market: String, price: BigDecimal?, volume: BigDecimal?): CompletableFuture<OrderResult>
 
     /**
      * 주문을 취소합니다.

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/ExchangeService.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/ExchangeService.kt
@@ -1,0 +1,65 @@
+package me.onetwo.aiautotrade.infrastructure.exchange
+
+import me.onetwo.aiautotrade.common.dto.AccountInfo
+import me.onetwo.aiautotrade.common.dto.MarketPrice
+import me.onetwo.aiautotrade.common.dto.OrderResult
+import java.util.concurrent.CompletableFuture
+
+/**
+ * 거래소 서비스 인터페이스
+ *
+ * 거래소와의 모든 상호작용을 담당합니다.
+ */
+interface ExchangeService {
+
+    /**
+     * 계정 정보를 조회합니다.
+     *
+     * @return 보유 자산 및 잔고 정보
+     */
+    fun getAccountInfo(): CompletableFuture<AccountInfo>
+
+    /**
+     * 특정 마켓의 현재 가격 정보를 조회합니다.
+     *
+     * @param market 마켓 코드 (예: KRW-BTC)
+     * @return 시장 가격 정보
+     */
+    fun getMarketPrice(market: String): CompletableFuture<MarketPrice>
+
+    /**
+     * 매수 주문을 실행합니다.
+     *
+     * @param market 마켓 코드
+     * @param price 주문 가격
+     * @param volume 주문 수량
+     * @return 주문 결과
+     */
+    fun buy(market: String, price: java.math.BigDecimal?, volume: java.math.BigDecimal?): CompletableFuture<OrderResult>
+
+    /**
+     * 매도 주문을 실행합니다.
+     *
+     * @param market 마켓 코드
+     * @param price 주문 가격
+     * @param volume 주문 수량
+     * @return 주문 결과
+     */
+    fun sell(market: String, price: java.math.BigDecimal?, volume: java.math.BigDecimal?): CompletableFuture<OrderResult>
+
+    /**
+     * 주문을 취소합니다.
+     *
+     * @param orderId 주문 ID
+     * @return 취소된 주문 정보
+     */
+    fun cancelOrder(orderId: String): CompletableFuture<OrderResult>
+
+    /**
+     * 주문 상태를 조회합니다.
+     *
+     * @param orderId 주문 ID
+     * @return 주문 정보
+     */
+    fun getOrderStatus(orderId: String): CompletableFuture<OrderResult>
+}

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/provider/UpbitExchangeProvider.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/provider/UpbitExchangeProvider.kt
@@ -50,6 +50,8 @@ class UpbitExchangeProvider(
                     )
                 }
 
+                // TODO: 모든 자산을 KRW로 환산하여 총 자산 계산
+                // 현재는 KRW 잔액만 계산하며, 추후 코인 자산도 현재가 기준으로 KRW 환산 필요
                 val totalBalance = balances
                     .filter { it.currency == "KRW" }
                     .sumOf { it.balance + it.locked }
@@ -205,7 +207,7 @@ class UpbitExchangeProvider(
         "limit" -> OrderType.LIMIT
         "price" -> OrderType.PRICE
         "market" -> OrderType.MARKET
-        else -> OrderType.LIMIT
+        else -> throw IllegalArgumentException("Unknown order type from Upbit: $ordType")
     }
 
     /**
@@ -216,7 +218,7 @@ class UpbitExchangeProvider(
         "watch" -> OrderState.WATCH
         "done" -> OrderState.DONE
         "cancel" -> OrderState.CANCEL
-        else -> OrderState.WAIT
+        else -> throw IllegalArgumentException("Unknown order state from Upbit: $state")
     }
 
     /**

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/provider/UpbitExchangeProvider.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/provider/UpbitExchangeProvider.kt
@@ -1,0 +1,228 @@
+package me.onetwo.aiautotrade.infrastructure.exchange.provider
+
+import me.onetwo.aiautotrade.common.dto.*
+import me.onetwo.aiautotrade.common.enums.OrderSide
+import me.onetwo.aiautotrade.common.enums.OrderState
+import me.onetwo.aiautotrade.common.enums.OrderType
+import me.onetwo.aiautotrade.infrastructure.exchange.ExchangeProvider
+import me.onetwo.aiautotrade.infrastructure.exchange.upbit.UpbitApiClient
+import me.onetwo.aiautotrade.infrastructure.exchange.upbit.dto.UpbitOrderRequest
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.CompletableFuture
+
+/**
+ * 업비트 거래소 Provider 구현체
+ *
+ * 업비트 API를 통해 거래소 기능을 제공합니다.
+ */
+@Component
+class UpbitExchangeProvider(
+    private val upbitApiClient: UpbitApiClient,
+    @Value("\${upbit.access-key:}") private val accessKey: String,
+    @Value("\${upbit.secret-key:}") private val secretKey: String
+) : ExchangeProvider {
+
+    private val logger = LoggerFactory.getLogger(UpbitExchangeProvider::class.java)
+
+    override fun getProviderName(): String = "upbit"
+
+    override fun isAvailable(): Boolean {
+        return accessKey.isNotBlank() && secretKey.isNotBlank()
+    }
+
+    override fun getAccountInfo(): CompletableFuture<AccountInfo> {
+        return upbitApiClient.getAccounts(accessKey, secretKey)
+            .toFuture()
+            .thenApply { upbitAccounts ->
+                val balances = upbitAccounts.map { account ->
+                    Balance(
+                        currency = account.currency,
+                        balance = account.balance,
+                        locked = account.locked,
+                        avgBuyPrice = account.avgBuyPrice
+                    )
+                }
+
+                val totalBalance = balances
+                    .filter { it.currency == "KRW" }
+                    .sumOf { it.balance + it.locked }
+
+                AccountInfo(
+                    balances = balances,
+                    totalBalance = totalBalance
+                )
+            }
+            .exceptionally { throwable ->
+                logger.error("Failed to get account info", throwable)
+                throw RuntimeException("Failed to get account info", throwable)
+            }
+    }
+
+    override fun getMarketPrice(market: String): CompletableFuture<MarketPrice> {
+        return upbitApiClient.getTicker(listOf(market))
+            .toFuture()
+            .thenApply { tickers ->
+                val ticker = tickers.firstOrNull()
+                    ?: throw IllegalStateException("No ticker data for market: $market")
+
+                MarketPrice(
+                    market = ticker.market,
+                    tradePrice = ticker.tradePrice,
+                    highPrice = ticker.highPrice,
+                    lowPrice = ticker.lowPrice,
+                    openPrice = ticker.openingPrice,
+                    prevClosingPrice = ticker.prevClosingPrice,
+                    changeRate = ticker.signedChangeRate,
+                    accTradeVolume24h = ticker.accTradeVolume24h,
+                    timestamp = LocalDateTime.ofInstant(
+                        Instant.ofEpochMilli(ticker.timestamp),
+                        ZoneId.systemDefault()
+                    )
+                )
+            }
+            .exceptionally { throwable ->
+                logger.error("Failed to get market price for: $market", throwable)
+                throw RuntimeException("Failed to get market price", throwable)
+            }
+    }
+
+    override fun placeOrder(orderRequest: OrderRequest): CompletableFuture<OrderResult> {
+        val upbitOrderRequest = UpbitOrderRequest(
+            market = orderRequest.market,
+            side = mapOrderSide(orderRequest.side),
+            ordType = mapOrderType(orderRequest.orderType),
+            volume = orderRequest.volume,
+            price = orderRequest.price
+        )
+
+        return upbitApiClient.placeOrder(accessKey, secretKey, upbitOrderRequest)
+            .toFuture()
+            .thenApply { response ->
+                OrderResult(
+                    orderId = response.uuid,
+                    market = response.market,
+                    side = OrderSide.valueOf(response.side.uppercase()),
+                    orderType = mapUpbitOrderType(response.ordType),
+                    price = response.price,
+                    volume = response.volume ?: BigDecimal.ZERO,
+                    executedVolume = response.executedVolume ?: BigDecimal.ZERO,
+                    remainingVolume = response.remainingVolume ?: BigDecimal.ZERO,
+                    state = mapOrderState(response.state),
+                    createdAt = parseDateTime(response.createdAt)
+                )
+            }
+            .exceptionally { throwable ->
+                logger.error("Failed to place order: $orderRequest", throwable)
+                throw RuntimeException("Failed to place order", throwable)
+            }
+    }
+
+    override fun cancelOrder(orderId: String): CompletableFuture<OrderResult> {
+        return upbitApiClient.cancelOrder(accessKey, secretKey, orderId)
+            .toFuture()
+            .thenApply { response ->
+                OrderResult(
+                    orderId = response.uuid,
+                    market = response.market,
+                    side = OrderSide.valueOf(response.side.uppercase()),
+                    orderType = mapUpbitOrderType(response.ordType),
+                    price = response.price,
+                    volume = response.volume ?: BigDecimal.ZERO,
+                    executedVolume = response.executedVolume ?: BigDecimal.ZERO,
+                    remainingVolume = response.remainingVolume ?: BigDecimal.ZERO,
+                    state = mapOrderState(response.state),
+                    createdAt = parseDateTime(response.createdAt)
+                )
+            }
+            .exceptionally { throwable ->
+                logger.error("Failed to cancel order: $orderId", throwable)
+                throw RuntimeException("Failed to cancel order", throwable)
+            }
+    }
+
+    override fun getOrder(orderId: String): CompletableFuture<OrderResult> {
+        return upbitApiClient.getOrder(accessKey, secretKey, orderId)
+            .toFuture()
+            .thenApply { response ->
+                OrderResult(
+                    orderId = response.uuid,
+                    market = response.market,
+                    side = OrderSide.valueOf(response.side.uppercase()),
+                    orderType = mapUpbitOrderType(response.ordType),
+                    price = response.price,
+                    volume = response.volume ?: BigDecimal.ZERO,
+                    executedVolume = response.executedVolume ?: BigDecimal.ZERO,
+                    remainingVolume = response.remainingVolume ?: BigDecimal.ZERO,
+                    state = mapOrderState(response.state),
+                    createdAt = parseDateTime(response.createdAt)
+                )
+            }
+            .exceptionally { throwable ->
+                logger.error("Failed to get order: $orderId", throwable)
+                throw RuntimeException("Failed to get order", throwable)
+            }
+    }
+
+    override fun initialize() {
+        logger.info("Upbit Exchange Provider initialized")
+        if (!isAvailable()) {
+            logger.warn("Upbit API keys are not configured")
+        }
+    }
+
+    override fun shutdown() {
+        logger.info("Upbit Exchange Provider shutdown")
+    }
+
+    /**
+     * OrderSide를 업비트 형식으로 변환
+     */
+    private fun mapOrderSide(side: OrderSide): String = when (side) {
+        OrderSide.BID -> "bid"
+        OrderSide.ASK -> "ask"
+    }
+
+    /**
+     * OrderType을 업비트 형식으로 변환
+     */
+    private fun mapOrderType(type: OrderType): String = when (type) {
+        OrderType.LIMIT -> "limit"
+        OrderType.PRICE -> "price"
+        OrderType.MARKET -> "market"
+    }
+
+    /**
+     * 업비트 주문 타입을 OrderType으로 변환
+     */
+    private fun mapUpbitOrderType(ordType: String): OrderType = when (ordType) {
+        "limit" -> OrderType.LIMIT
+        "price" -> OrderType.PRICE
+        "market" -> OrderType.MARKET
+        else -> OrderType.LIMIT
+    }
+
+    /**
+     * 업비트 주문 상태를 OrderState로 변환
+     */
+    private fun mapOrderState(state: String): OrderState = when (state) {
+        "wait" -> OrderState.WAIT
+        "watch" -> OrderState.WATCH
+        "done" -> OrderState.DONE
+        "cancel" -> OrderState.CANCEL
+        else -> OrderState.WAIT
+    }
+
+    /**
+     * ISO 8601 형식의 날짜 문자열을 LocalDateTime으로 변환
+     */
+    private fun parseDateTime(dateString: String): LocalDateTime {
+        return LocalDateTime.parse(dateString, DateTimeFormatter.ISO_DATE_TIME)
+    }
+}

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/upbit/UpbitApiClient.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/upbit/UpbitApiClient.kt
@@ -1,0 +1,233 @@
+package me.onetwo.aiautotrade.infrastructure.exchange.upbit
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.jsonwebtoken.Jwts
+import me.onetwo.aiautotrade.infrastructure.exchange.upbit.dto.*
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
+import reactor.core.publisher.Mono
+import java.math.BigInteger
+import java.security.MessageDigest
+import java.util.*
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * 업비트 API 클라이언트
+ *
+ * 업비트 REST API와의 통신을 담당합니다.
+ * JWT 토큰 생성 및 HTTP 요청을 처리합니다.
+ */
+@Component
+class UpbitApiClient(
+    private val objectMapper: ObjectMapper
+) {
+    private val logger = LoggerFactory.getLogger(UpbitApiClient::class.java)
+
+    companion object {
+        private const val API_BASE_URL = "https://api.upbit.com"
+        private const val ACCOUNT_ENDPOINT = "/v1/accounts"
+        private const val TICKER_ENDPOINT = "/v1/ticker"
+        private const val ORDERS_ENDPOINT = "/v1/orders"
+        private const val ORDER_ENDPOINT = "/v1/order"
+    }
+
+    private val webClient: WebClient = WebClient.builder()
+        .baseUrl(API_BASE_URL)
+        .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .build()
+
+    /**
+     * 계좌 정보 조회
+     *
+     * @param accessKey API Access Key
+     * @param secretKey API Secret Key
+     * @return 계좌 정보 목록
+     */
+    fun getAccounts(accessKey: String, secretKey: String): Mono<List<UpbitAccount>> {
+        val token = generateToken(accessKey, secretKey)
+
+        return webClient.get()
+            .uri(ACCOUNT_ENDPOINT)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+            .retrieve()
+            .bodyToMono<List<UpbitAccount>>()
+            .doOnError { error ->
+                logger.error("Failed to get accounts", error)
+            }
+    }
+
+    /**
+     * 시세 티커 조회
+     *
+     * @param markets 마켓 코드 목록 (예: ["KRW-BTC", "KRW-ETH"])
+     * @return 시세 정보 목록
+     */
+    fun getTicker(markets: List<String>): Mono<List<UpbitTicker>> {
+        val marketsParam = markets.joinToString(",")
+
+        return webClient.get()
+            .uri { uriBuilder ->
+                uriBuilder.path(TICKER_ENDPOINT)
+                    .queryParam("markets", marketsParam)
+                    .build()
+            }
+            .retrieve()
+            .bodyToMono<List<UpbitTicker>>()
+            .doOnError { error ->
+                logger.error("Failed to get ticker for markets: $markets", error)
+            }
+    }
+
+    /**
+     * 주문하기
+     *
+     * @param accessKey API Access Key
+     * @param secretKey API Secret Key
+     * @param orderRequest 주문 요청 정보
+     * @return 주문 결과
+     */
+    fun placeOrder(
+        accessKey: String,
+        secretKey: String,
+        orderRequest: UpbitOrderRequest
+    ): Mono<UpbitOrderResponse> {
+        val queryString = buildQueryString(orderRequest)
+        val token = generateToken(accessKey, secretKey, queryString)
+
+        return webClient.post()
+            .uri(ORDERS_ENDPOINT)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+            .bodyValue(orderRequest)
+            .retrieve()
+            .bodyToMono<UpbitOrderResponse>()
+            .doOnError { error ->
+                logger.error("Failed to place order: $orderRequest", error)
+            }
+    }
+
+    /**
+     * 주문 조회
+     *
+     * @param accessKey API Access Key
+     * @param secretKey API Secret Key
+     * @param orderId 주문 ID
+     * @return 주문 정보
+     */
+    fun getOrder(
+        accessKey: String,
+        secretKey: String,
+        orderId: String
+    ): Mono<UpbitOrderResponse> {
+        val queryParams = mapOf("uuid" to orderId)
+        val queryString = buildQueryString(queryParams)
+        val token = generateToken(accessKey, secretKey, queryString)
+
+        return webClient.get()
+            .uri { uriBuilder ->
+                uriBuilder.path(ORDER_ENDPOINT)
+                    .queryParam("uuid", orderId)
+                    .build()
+            }
+            .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+            .retrieve()
+            .bodyToMono<UpbitOrderResponse>()
+            .doOnError { error ->
+                logger.error("Failed to get order: $orderId", error)
+            }
+    }
+
+    /**
+     * 주문 취소
+     *
+     * @param accessKey API Access Key
+     * @param secretKey API Secret Key
+     * @param orderId 주문 ID
+     * @return 취소된 주문 정보
+     */
+    fun cancelOrder(
+        accessKey: String,
+        secretKey: String,
+        orderId: String
+    ): Mono<UpbitOrderResponse> {
+        val queryParams = mapOf("uuid" to orderId)
+        val queryString = buildQueryString(queryParams)
+        val token = generateToken(accessKey, secretKey, queryString)
+
+        return webClient.delete()
+            .uri { uriBuilder ->
+                uriBuilder.path(ORDER_ENDPOINT)
+                    .queryParam("uuid", orderId)
+                    .build()
+            }
+            .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+            .retrieve()
+            .bodyToMono<UpbitOrderResponse>()
+            .doOnError { error ->
+                logger.error("Failed to cancel order: $orderId", error)
+            }
+    }
+
+    /**
+     * JWT 토큰 생성
+     *
+     * @param accessKey API Access Key
+     * @param secretKey API Secret Key
+     * @param queryString 쿼리 스트링 (선택)
+     * @return JWT 토큰
+     */
+    private fun generateToken(
+        accessKey: String,
+        secretKey: String,
+        queryString: String? = null
+    ): String {
+        val claims = mutableMapOf<String, Any>(
+            "access_key" to accessKey,
+            "nonce" to UUID.randomUUID().toString()
+        )
+
+        if (!queryString.isNullOrBlank()) {
+            val md = MessageDigest.getInstance("SHA-512")
+            md.update(queryString.toByteArray(Charsets.UTF_8))
+
+            val queryHash = String.format("%0128x", BigInteger(1, md.digest()))
+
+            claims["query_hash"] = queryHash
+            claims["query_hash_alg"] = "SHA512"
+        }
+
+        val key = SecretKeySpec(secretKey.toByteArray(Charsets.UTF_8), "HmacSHA256")
+
+        return Jwts.builder()
+            .claims(claims)
+            .signWith(key)
+            .compact()
+    }
+
+    /**
+     * 쿼리 스트링 생성
+     *
+     * @param params 파라미터 맵
+     * @return 쿼리 스트링
+     */
+    private fun buildQueryString(params: Map<String, Any?>): String {
+        return params.entries
+            .filter { it.value != null }
+            .joinToString("&") { "${it.key}=${it.value}" }
+    }
+
+    /**
+     * 객체를 쿼리 스트링으로 변환
+     *
+     * @param obj 변환할 객체
+     * @return 쿼리 스트링
+     */
+    private fun buildQueryString(obj: Any): String {
+        val map = objectMapper.convertValue(obj, Map::class.java)
+        @Suppress("UNCHECKED_CAST")
+        return buildQueryString(map as Map<String, Any?>)
+    }
+}

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/upbit/UpbitApiClient.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/upbit/UpbitApiClient.kt
@@ -11,6 +11,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
 import java.math.BigInteger
+import java.net.URLEncoder
 import java.security.MessageDigest
 import java.util.*
 import javax.crypto.spec.SecretKeySpec
@@ -211,12 +212,14 @@ class UpbitApiClient(
      * 쿼리 스트링 생성
      *
      * @param params 파라미터 맵
-     * @return 쿼리 스트링
+     * @return 쿼리 스트링 (URL 인코딩 적용)
      */
     private fun buildQueryString(params: Map<String, Any?>): String {
         return params.entries
             .filter { it.value != null }
-            .joinToString("&") { "${it.key}=${it.value}" }
+            .joinToString("&") {
+                "${URLEncoder.encode(it.key, "UTF-8")}=${URLEncoder.encode(it.value.toString(), "UTF-8")}"
+            }
     }
 
     /**

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/upbit/dto/UpbitAccount.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/upbit/dto/UpbitAccount.kt
@@ -1,0 +1,33 @@
+package me.onetwo.aiautotrade.infrastructure.exchange.upbit.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.math.BigDecimal
+
+/**
+ * 업비트 계좌 정보 응답
+ */
+data class UpbitAccount(
+    /** 화폐 코드 */
+    @JsonProperty("currency")
+    val currency: String,
+
+    /** 주문 가능 금액/수량 */
+    @JsonProperty("balance")
+    val balance: BigDecimal,
+
+    /** 주문 중 묶여있는 금액/수량 */
+    @JsonProperty("locked")
+    val locked: BigDecimal,
+
+    /** 매수 평균가 */
+    @JsonProperty("avg_buy_price")
+    val avgBuyPrice: BigDecimal,
+
+    /** 매수/매도 가능 여부 */
+    @JsonProperty("avg_buy_price_modified")
+    val avgBuyPriceModified: Boolean,
+
+    /** 평단가 기준 화폐 */
+    @JsonProperty("unit_currency")
+    val unitCurrency: String
+)

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/upbit/dto/UpbitOrderRequest.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/upbit/dto/UpbitOrderRequest.kt
@@ -1,0 +1,29 @@
+package me.onetwo.aiautotrade.infrastructure.exchange.upbit.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.math.BigDecimal
+
+/**
+ * 업비트 주문 요청
+ */
+data class UpbitOrderRequest(
+    /** 마켓 코드 (필수) */
+    @JsonProperty("market")
+    val market: String,
+
+    /** 주문 종류 (필수) - bid: 매수, ask: 매도 */
+    @JsonProperty("side")
+    val side: String,
+
+    /** 주문량 (지정가, 시장가 매도 시 필수) */
+    @JsonProperty("volume")
+    val volume: BigDecimal? = null,
+
+    /** 주문 가격 (지정가 시 필수) */
+    @JsonProperty("price")
+    val price: BigDecimal? = null,
+
+    /** 주문 타입 (필수) - limit: 지정가, price: 시장가 매수, market: 시장가 매도 */
+    @JsonProperty("ord_type")
+    val ordType: String
+)

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/upbit/dto/UpbitOrderResponse.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/upbit/dto/UpbitOrderResponse.kt
@@ -1,0 +1,69 @@
+package me.onetwo.aiautotrade.infrastructure.exchange.upbit.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.math.BigDecimal
+
+/**
+ * 업비트 주문 응답
+ */
+data class UpbitOrderResponse(
+    /** 주문 고유 ID */
+    @JsonProperty("uuid")
+    val uuid: String,
+
+    /** 주문 종류 */
+    @JsonProperty("side")
+    val side: String,
+
+    /** 주문 타입 */
+    @JsonProperty("ord_type")
+    val ordType: String,
+
+    /** 주문 가격 */
+    @JsonProperty("price")
+    val price: BigDecimal?,
+
+    /** 주문 상태 */
+    @JsonProperty("state")
+    val state: String,
+
+    /** 마켓 코드 */
+    @JsonProperty("market")
+    val market: String,
+
+    /** 주문 생성 시각 */
+    @JsonProperty("created_at")
+    val createdAt: String,
+
+    /** 주문량 */
+    @JsonProperty("volume")
+    val volume: BigDecimal?,
+
+    /** 남은 주문량 */
+    @JsonProperty("remaining_volume")
+    val remainingVolume: BigDecimal?,
+
+    /** 예약 주문량 */
+    @JsonProperty("reserved_fee")
+    val reservedFee: BigDecimal?,
+
+    /** 남은 수수료 */
+    @JsonProperty("remaining_fee")
+    val remainingFee: BigDecimal?,
+
+    /** 사용된 수수료 */
+    @JsonProperty("paid_fee")
+    val paidFee: BigDecimal?,
+
+    /** 잠긴 금액 */
+    @JsonProperty("locked")
+    val locked: BigDecimal?,
+
+    /** 체결된 양 */
+    @JsonProperty("executed_volume")
+    val executedVolume: BigDecimal?,
+
+    /** 체결된 거래 수 */
+    @JsonProperty("trades_count")
+    val tradesCount: Int?
+)

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/upbit/dto/UpbitTicker.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/upbit/dto/UpbitTicker.kt
@@ -1,0 +1,45 @@
+package me.onetwo.aiautotrade.infrastructure.exchange.upbit.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.math.BigDecimal
+
+/**
+ * 업비트 시세 티커 응답
+ */
+data class UpbitTicker(
+    /** 마켓 코드 */
+    @JsonProperty("market")
+    val market: String,
+
+    /** 현재가 */
+    @JsonProperty("trade_price")
+    val tradePrice: BigDecimal,
+
+    /** 고가 */
+    @JsonProperty("high_price")
+    val highPrice: BigDecimal,
+
+    /** 저가 */
+    @JsonProperty("low_price")
+    val lowPrice: BigDecimal,
+
+    /** 시가 */
+    @JsonProperty("opening_price")
+    val openingPrice: BigDecimal,
+
+    /** 전일 종가 */
+    @JsonProperty("prev_closing_price")
+    val prevClosingPrice: BigDecimal,
+
+    /** 변화율 */
+    @JsonProperty("signed_change_rate")
+    val signedChangeRate: BigDecimal,
+
+    /** 24시간 누적 거래량 */
+    @JsonProperty("acc_trade_volume_24h")
+    val accTradeVolume24h: BigDecimal,
+
+    /** 타임스탬프 (밀리초) */
+    @JsonProperty("timestamp")
+    val timestamp: Long
+)

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/llm/DefaultLlmService.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/llm/DefaultLlmService.kt
@@ -21,7 +21,7 @@ import javax.annotation.PreDestroy
 /**
  * LLM 서비스 구현체
  *
- * 주식 자동매매 시스템에서 AI 기반 분석 및 의사결정을 담당합니다.
+ * 자동매매 시스템에서 AI 기반 분석 및 의사결정을 담당합니다.
  * 다양한 LLM 제공업체를 통해 시장 분석, 매매 신호 분석 등의 기능을 제공합니다.
  *
  * @property llmProvider LLM 제공업체 (Vertex AI, OpenAI 등)
@@ -62,7 +62,7 @@ class DefaultLlmService(
     }
 
     /**
-     * 주식 매매 신호를 분석하여 매매 결정을 제공합니다.
+     * 매매 신호를 분석하여 매매 결정을 제공합니다.
      *
      * @param marketData 시장 데이터 (가격, 거래량 등)
      * @param technicalIndicators 기술적 지표
@@ -104,9 +104,9 @@ class DefaultLlmService(
     }
 
     /**
-     * 특정 주식의 시장 분석 리포트를 생성합니다.
+     * 특정 종목의 시장 분석 리포트를 생성합니다.
      *
-     * @param symbol 주식 종목 코드
+     * @param symbol 종목 코드
      * @param timeframe 분석 시간 프레임
      * @param marketData 시장 데이터
      * @return AI가 생성한 시장 분석 리포트

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/llm/LlmService.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/llm/LlmService.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.CompletableFuture
 /**
  * LLM(Large Language Model) 서비스 인터페이스
  * 
- * 주식 자동매매 시스템에서 AI 분석을 위한 핵심 서비스입니다.
+ * 자동매매 시스템에서 AI 분석을 위한 핵심 서비스입니다.
  * Vertex AI를 통해 매매 결정, 시장 분석 등의 기능을 제공합니다.
  */
 interface LlmService {
@@ -22,7 +22,7 @@ interface LlmService {
     fun generateText(request: LlmRequest): CompletableFuture<LlmResponse>
     
     /**
-     * 주식 매매 신호를 분석하여 매매 결정을 제공합니다.
+     * 매매 신호를 분석하여 매매 결정을 제공합니다.
      *
      * @param marketData 시장 데이터 (가격, 거래량 등)
      * @param technicalIndicators 기술적 지표 (RSI, MACD, 이동평균 등)
@@ -36,9 +36,9 @@ interface LlmService {
     ): CompletableFuture<TradingDecision>
     
     /**
-     * 특정 주식의 시장 분석 리포트를 생성합니다.
+     * 특정 종목의 시장 분석 리포트를 생성합니다.
      *
-     * @param symbol 주식 종목 코드
+     * @param symbol 종목 코드
      * @param timeframe 분석 시간 프레임
      * @param marketData 시장 데이터
      * @return 시장 분석 리포트를 포함한 CompletableFuture

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/llm/PromptTemplateServiceImpl.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/llm/PromptTemplateServiceImpl.kt
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service
 class PromptTemplateServiceImpl : PromptTemplateService {
 
     /**
-     * 주식 매매 분석을 위한 프롬프트를 생성합니다.
+     * 매매 분석을 위한 프롬프트를 생성합니다.
      *
      * @param marketData 시장 데이터 (가격, 거래량 등)
      * @param technicalIndicators 기술적 지표 (RSI, MACD, 이동평균 등)
@@ -23,7 +23,7 @@ class PromptTemplateServiceImpl : PromptTemplateService {
         val newsContextStr = newsContext.joinToString("\n- ") { it }
 
         return """
-            당신은 주식 자동매매 전문 AI 분석가입니다.
+            당신은 자동매매 전문 AI 분석가입니다.
             아래 정보를 바탕으로 매매 결정을 내려주세요.
 
             ## 시장 데이터
@@ -59,9 +59,9 @@ class PromptTemplateServiceImpl : PromptTemplateService {
     }
 
     /**
-     * 주식 시장 분석을 위한 프롬프트를 생성합니다.
+     * 시장 분석을 위한 프롬프트를 생성합니다.
      *
-     * @param symbol 분석할 주식 종목 코드
+     * @param symbol 분석할 종목 코드
      * @param timeframe 분석 시간 프레임 (1일, 1주, 1개월 등)
      * @param marketData 시장 데이터
      * @return 시장 분석을 위한 구조화된 프롬프트
@@ -74,7 +74,7 @@ class PromptTemplateServiceImpl : PromptTemplateService {
         val marketDataStr = marketData.entries.joinToString("\n") { "${it.key}: ${it.value}" }
 
         return """
-            당신은 주식 시장 분석 전문가입니다.
+            당신은 시장 분석 전문가입니다.
             다음 정보를 바탕으로 $symbol 종목의 시장 분석을 제공해주세요.
 
             ## 분석 대상
@@ -102,7 +102,7 @@ class PromptTemplateServiceImpl : PromptTemplateService {
     }
 
     /**
-     * 주식 포지션 리스크 분석을 위한 프롬프트를 생성합니다.
+     * 포지션 리스크 분석을 위한 프롬프트를 생성합니다.
      *
      * @param position 현재 보유 포지션 정보
      * @param marketConditions 현재 시장 상황
@@ -116,7 +116,7 @@ class PromptTemplateServiceImpl : PromptTemplateService {
         val marketConditionsStr = marketConditions.entries.joinToString("\n") { "${it.key}: ${it.value}" }
 
         return """
-            당신은 주식 리스크 관리 전문가입니다.
+            당신은 리스크 관리 전문가입니다.
             현재 포지션과 시장 상황을 분석하여 위험도를 평가해주세요.
 
             ## 현재 포지션

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/security/AesEncryptionService.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/security/AesEncryptionService.kt
@@ -1,0 +1,57 @@
+package me.onetwo.aiautotrade.infrastructure.security
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.util.*
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * AES 암호화 서비스 구현체
+ *
+ * AES-256-CBC 알고리즘을 사용하여 데이터를 암호화/복호화합니다.
+ */
+@Service
+class AesEncryptionService(
+    @Value("\${encryption.key:0123456789abcdef0123456789abcdef}") private val encryptionKey: String,
+    @Value("\${encryption.iv:fedcba9876543210}") private val initVector: String
+) : EncryptionService {
+
+    companion object {
+        private const val ALGORITHM = "AES/CBC/PKCS5PADDING"
+        private const val CHARSET = "UTF-8"
+    }
+
+    init {
+        require(encryptionKey.length == 32) {
+            "Encryption key must be 32 characters (256 bits) long"
+        }
+        require(initVector.length == 16) {
+            "Initialization vector must be 16 characters (128 bits) long"
+        }
+    }
+
+    override fun encrypt(plainText: String): String {
+        val cipher = Cipher.getInstance(ALGORITHM)
+        val keySpec = SecretKeySpec(encryptionKey.toByteArray(charset(CHARSET)), "AES")
+        val ivSpec = IvParameterSpec(initVector.toByteArray(charset(CHARSET)))
+
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, ivSpec)
+
+        val encrypted = cipher.doFinal(plainText.toByteArray(charset(CHARSET)))
+        return Base64.getEncoder().encodeToString(encrypted)
+    }
+
+    override fun decrypt(encryptedText: String): String {
+        val cipher = Cipher.getInstance(ALGORITHM)
+        val keySpec = SecretKeySpec(encryptionKey.toByteArray(charset(CHARSET)), "AES")
+        val ivSpec = IvParameterSpec(initVector.toByteArray(charset(CHARSET)))
+
+        cipher.init(Cipher.DECRYPT_MODE, keySpec, ivSpec)
+
+        val decodedValue = Base64.getDecoder().decode(encryptedText)
+        val decrypted = cipher.doFinal(decodedValue)
+        return String(decrypted, charset(CHARSET))
+    }
+}

--- a/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/security/EncryptionService.kt
+++ b/src/main/kotlin/me/onetwo/aiautotrade/infrastructure/security/EncryptionService.kt
@@ -1,0 +1,25 @@
+package me.onetwo.aiautotrade.infrastructure.security
+
+/**
+ * 암호화 서비스 인터페이스
+ *
+ * 민감한 정보(API 키 등)를 암호화하고 복호화합니다.
+ */
+interface EncryptionService {
+
+    /**
+     * 텍스트를 암호화합니다.
+     *
+     * @param plainText 평문
+     * @return 암호화된 텍스트 (Base64 인코딩)
+     */
+    fun encrypt(plainText: String): String
+
+    /**
+     * 암호화된 텍스트를 복호화합니다.
+     *
+     * @param encryptedText 암호화된 텍스트 (Base64 인코딩)
+     * @return 평문
+     */
+    fun decrypt(encryptedText: String): String
+}

--- a/src/test/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/DefaultApiKeyServiceTest.kt
+++ b/src/test/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/DefaultApiKeyServiceTest.kt
@@ -1,0 +1,194 @@
+package me.onetwo.aiautotrade.infrastructure.exchange
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import me.onetwo.aiautotrade.infrastructure.security.EncryptionService
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class DefaultApiKeyServiceTest {
+
+    private lateinit var encryptionService: EncryptionService
+    private lateinit var apiKeyService: ApiKeyService
+
+    @BeforeEach
+    fun setUp() {
+        encryptionService = mockk()
+        apiKeyService = DefaultApiKeyService(encryptionService)
+    }
+
+    @Test
+    fun `saveApiKey should encrypt and store API keys`() {
+        // given
+        val userId = 1L
+        val exchangeName = "upbit"
+        val accessKey = "my-access-key"
+        val secretKey = "my-secret-key"
+        val encryptedAccessKey = "encrypted-access-key"
+        val encryptedSecretKey = "encrypted-secret-key"
+
+        every { encryptionService.encrypt(accessKey) } returns encryptedAccessKey
+        every { encryptionService.encrypt(secretKey) } returns encryptedSecretKey
+
+        // when
+        val result = apiKeyService.saveApiKey(userId, exchangeName, accessKey, secretKey)
+
+        // then
+        assertNotNull(result)
+        assertEquals(userId, result.userId)
+        assertEquals(exchangeName, result.exchangeName)
+        assertEquals(accessKey, result.accessKey) // 반환값은 평문
+        assertEquals(secretKey, result.secretKey) // 반환값은 평문
+
+        verify { encryptionService.encrypt(accessKey) }
+        verify { encryptionService.encrypt(secretKey) }
+    }
+
+    @Test
+    fun `getApiKey should decrypt and return API keys`() {
+        // given
+        val userId = 1L
+        val exchangeName = "upbit"
+        val accessKey = "my-access-key"
+        val secretKey = "my-secret-key"
+        val encryptedAccessKey = "encrypted-access-key"
+        val encryptedSecretKey = "encrypted-secret-key"
+
+        every { encryptionService.encrypt(accessKey) } returns encryptedAccessKey
+        every { encryptionService.encrypt(secretKey) } returns encryptedSecretKey
+        every { encryptionService.decrypt(encryptedAccessKey) } returns accessKey
+        every { encryptionService.decrypt(encryptedSecretKey) } returns secretKey
+
+        apiKeyService.saveApiKey(userId, exchangeName, accessKey, secretKey)
+
+        // when
+        val result = apiKeyService.getApiKey(userId, exchangeName)
+
+        // then
+        assertNotNull(result)
+        assertEquals(userId, result!!.userId)
+        assertEquals(exchangeName, result.exchangeName)
+        assertEquals(accessKey, result.accessKey)
+        assertEquals(secretKey, result.secretKey)
+
+        verify { encryptionService.decrypt(encryptedAccessKey) }
+        verify { encryptionService.decrypt(encryptedSecretKey) }
+    }
+
+    @Test
+    fun `getApiKey should return null for non-existent key`() {
+        // given
+        val userId = 1L
+        val exchangeName = "upbit"
+
+        // when
+        val result = apiKeyService.getApiKey(userId, exchangeName)
+
+        // then
+        assertNull(result)
+    }
+
+    @Test
+    fun `updateApiKey should update existing API keys`() {
+        // given
+        val userId = 1L
+        val exchangeName = "upbit"
+        val oldAccessKey = "old-access-key"
+        val oldSecretKey = "old-secret-key"
+        val newAccessKey = "new-access-key"
+        val newSecretKey = "new-secret-key"
+
+        every { encryptionService.encrypt(any()) } answers { "encrypted-${firstArg<String>()}" }
+        every { encryptionService.decrypt(any()) } answers { (firstArg() as String).removePrefix("encrypted-") }
+
+        apiKeyService.saveApiKey(userId, exchangeName, oldAccessKey, oldSecretKey)
+
+        // when
+        val result = apiKeyService.updateApiKey(userId, exchangeName, newAccessKey, newSecretKey)
+
+        // then
+        assertNotNull(result)
+        assertEquals(newAccessKey, result.accessKey)
+        assertEquals(newSecretKey, result.secretKey)
+    }
+
+    @Test
+    fun `updateApiKey should throw exception for non-existent key`() {
+        // given
+        val userId = 1L
+        val exchangeName = "upbit"
+        val accessKey = "access-key"
+        val secretKey = "secret-key"
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            apiKeyService.updateApiKey(userId, exchangeName, accessKey, secretKey)
+        }
+    }
+
+    @Test
+    fun `deleteApiKey should remove API keys`() {
+        // given
+        val userId = 1L
+        val exchangeName = "upbit"
+        val accessKey = "my-access-key"
+        val secretKey = "my-secret-key"
+
+        every { encryptionService.encrypt(any()) } returns "encrypted"
+
+        apiKeyService.saveApiKey(userId, exchangeName, accessKey, secretKey)
+
+        // when
+        apiKeyService.deleteApiKey(userId, exchangeName)
+        val result = apiKeyService.getApiKey(userId, exchangeName)
+
+        // then
+        assertNull(result)
+    }
+
+    @Test
+    fun `getAllApiKeys should return all keys for user`() {
+        // given
+        val userId = 1L
+        val exchange1 = "upbit"
+        val exchange2 = "binance"
+
+        every { encryptionService.encrypt(any()) } answers { "encrypted-${firstArg<String>()}" }
+        every { encryptionService.decrypt(any()) } answers { (firstArg() as String).removePrefix("encrypted-") }
+
+        apiKeyService.saveApiKey(userId, exchange1, "access1", "secret1")
+        apiKeyService.saveApiKey(userId, exchange2, "access2", "secret2")
+
+        // when
+        val result = apiKeyService.getAllApiKeys(userId)
+
+        // then
+        assertEquals(2, result.size)
+        assertTrue(result.any { it.exchangeName == exchange1 })
+        assertTrue(result.any { it.exchangeName == exchange2 })
+    }
+
+    @Test
+    fun `getAllApiKeys should return only keys for specific user`() {
+        // given
+        val userId1 = 1L
+        val userId2 = 2L
+        val exchangeName = "upbit"
+
+        every { encryptionService.encrypt(any()) } answers { "encrypted-${firstArg<String>()}" }
+        every { encryptionService.decrypt(any()) } answers { (firstArg() as String).removePrefix("encrypted-") }
+
+        apiKeyService.saveApiKey(userId1, exchangeName, "access1", "secret1")
+        apiKeyService.saveApiKey(userId2, exchangeName, "access2", "secret2")
+
+        // when
+        val result = apiKeyService.getAllApiKeys(userId1)
+
+        // then
+        assertEquals(1, result.size)
+        assertEquals(userId1, result[0].userId)
+    }
+}

--- a/src/test/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/DefaultExchangeServiceTest.kt
+++ b/src/test/kotlin/me/onetwo/aiautotrade/infrastructure/exchange/DefaultExchangeServiceTest.kt
@@ -1,0 +1,271 @@
+package me.onetwo.aiautotrade.infrastructure.exchange
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import me.onetwo.aiautotrade.common.dto.*
+import me.onetwo.aiautotrade.common.enums.OrderSide
+import me.onetwo.aiautotrade.common.enums.OrderState
+import me.onetwo.aiautotrade.common.enums.OrderType
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.concurrent.CompletableFuture
+
+class DefaultExchangeServiceTest {
+
+    private lateinit var exchangeProvider: ExchangeProvider
+    private lateinit var exchangeService: ExchangeService
+
+    @BeforeEach
+    fun setUp() {
+        exchangeProvider = mockk(relaxed = true)
+        exchangeService = DefaultExchangeService(exchangeProvider)
+
+        every { exchangeProvider.getProviderName() } returns "mock-exchange"
+    }
+
+    @Test
+    fun `getAccountInfo should delegate to provider`() {
+        // given
+        val expectedAccountInfo = AccountInfo(
+            balances = listOf(
+                Balance("KRW", BigDecimal("1000000"), BigDecimal.ZERO)
+            ),
+            totalBalance = BigDecimal("1000000")
+        )
+
+        every { exchangeProvider.getAccountInfo() } returns CompletableFuture.completedFuture(expectedAccountInfo)
+
+        // when
+        val result = exchangeService.getAccountInfo().get()
+
+        // then
+        assertNotNull(result)
+        assertEquals(expectedAccountInfo, result)
+        verify { exchangeProvider.getAccountInfo() }
+    }
+
+    @Test
+    fun `getMarketPrice should delegate to provider`() {
+        // given
+        val market = "KRW-BTC"
+        val expectedPrice = MarketPrice(
+            market = market,
+            tradePrice = BigDecimal("50000000"),
+            highPrice = BigDecimal("51000000"),
+            lowPrice = BigDecimal("49000000"),
+            openPrice = BigDecimal("50000000"),
+            prevClosingPrice = BigDecimal("49500000"),
+            changeRate = BigDecimal("0.01"),
+            accTradeVolume24h = BigDecimal("100"),
+            timestamp = LocalDateTime.now()
+        )
+
+        every { exchangeProvider.getMarketPrice(market) } returns CompletableFuture.completedFuture(expectedPrice)
+
+        // when
+        val result = exchangeService.getMarketPrice(market).get()
+
+        // then
+        assertNotNull(result)
+        assertEquals(expectedPrice, result)
+        verify { exchangeProvider.getMarketPrice(market) }
+    }
+
+    @Test
+    fun `buy with price and volume should place limit order`() {
+        // given
+        val market = "KRW-BTC"
+        val price = BigDecimal("50000000")
+        val volume = BigDecimal("0.1")
+
+        val expectedOrder = OrderResult(
+            orderId = "order-123",
+            market = market,
+            side = OrderSide.BID,
+            orderType = OrderType.LIMIT,
+            price = price,
+            volume = volume,
+            executedVolume = BigDecimal.ZERO,
+            remainingVolume = volume,
+            state = OrderState.WAIT,
+            createdAt = LocalDateTime.now()
+        )
+
+        every { exchangeProvider.placeOrder(any()) } returns CompletableFuture.completedFuture(expectedOrder)
+
+        // when
+        val result = exchangeService.buy(market, price, volume).get()
+
+        // then
+        assertNotNull(result)
+        assertEquals(OrderType.LIMIT, result.orderType)
+        verify {
+            exchangeProvider.placeOrder(match {
+                it.orderType == OrderType.LIMIT && it.side == OrderSide.BID
+            })
+        }
+    }
+
+    @Test
+    fun `buy with only price should place market price order`() {
+        // given
+        val market = "KRW-BTC"
+        val price = BigDecimal("5000000")
+
+        val expectedOrder = OrderResult(
+            orderId = "order-123",
+            market = market,
+            side = OrderSide.BID,
+            orderType = OrderType.PRICE,
+            price = price,
+            volume = BigDecimal.ZERO,
+            executedVolume = BigDecimal.ZERO,
+            remainingVolume = BigDecimal.ZERO,
+            state = OrderState.WAIT,
+            createdAt = LocalDateTime.now()
+        )
+
+        every { exchangeProvider.placeOrder(any()) } returns CompletableFuture.completedFuture(expectedOrder)
+
+        // when
+        val result = exchangeService.buy(market, price, null).get()
+
+        // then
+        assertNotNull(result)
+        assertEquals(OrderType.PRICE, result.orderType)
+        verify {
+            exchangeProvider.placeOrder(match {
+                it.orderType == OrderType.PRICE && it.side == OrderSide.BID
+            })
+        }
+    }
+
+    @Test
+    fun `sell with price and volume should place limit order`() {
+        // given
+        val market = "KRW-BTC"
+        val price = BigDecimal("50000000")
+        val volume = BigDecimal("0.1")
+
+        val expectedOrder = OrderResult(
+            orderId = "order-123",
+            market = market,
+            side = OrderSide.ASK,
+            orderType = OrderType.LIMIT,
+            price = price,
+            volume = volume,
+            executedVolume = BigDecimal.ZERO,
+            remainingVolume = volume,
+            state = OrderState.WAIT,
+            createdAt = LocalDateTime.now()
+        )
+
+        every { exchangeProvider.placeOrder(any()) } returns CompletableFuture.completedFuture(expectedOrder)
+
+        // when
+        val result = exchangeService.sell(market, price, volume).get()
+
+        // then
+        assertNotNull(result)
+        assertEquals(OrderType.LIMIT, result.orderType)
+        verify {
+            exchangeProvider.placeOrder(match {
+                it.orderType == OrderType.LIMIT && it.side == OrderSide.ASK
+            })
+        }
+    }
+
+    @Test
+    fun `sell with only volume should place market order`() {
+        // given
+        val market = "KRW-BTC"
+        val volume = BigDecimal("0.1")
+
+        val expectedOrder = OrderResult(
+            orderId = "order-123",
+            market = market,
+            side = OrderSide.ASK,
+            orderType = OrderType.MARKET,
+            price = null,
+            volume = volume,
+            executedVolume = BigDecimal.ZERO,
+            remainingVolume = volume,
+            state = OrderState.WAIT,
+            createdAt = LocalDateTime.now()
+        )
+
+        every { exchangeProvider.placeOrder(any()) } returns CompletableFuture.completedFuture(expectedOrder)
+
+        // when
+        val result = exchangeService.sell(market, null, volume).get()
+
+        // then
+        assertNotNull(result)
+        assertEquals(OrderType.MARKET, result.orderType)
+        verify {
+            exchangeProvider.placeOrder(match {
+                it.orderType == OrderType.MARKET && it.side == OrderSide.ASK
+            })
+        }
+    }
+
+    @Test
+    fun `cancelOrder should delegate to provider`() {
+        // given
+        val orderId = "order-123"
+        val expectedOrder = OrderResult(
+            orderId = orderId,
+            market = "KRW-BTC",
+            side = OrderSide.BID,
+            orderType = OrderType.LIMIT,
+            price = BigDecimal("50000000"),
+            volume = BigDecimal("0.1"),
+            executedVolume = BigDecimal.ZERO,
+            remainingVolume = BigDecimal("0.1"),
+            state = OrderState.CANCEL,
+            createdAt = LocalDateTime.now()
+        )
+
+        every { exchangeProvider.cancelOrder(orderId) } returns CompletableFuture.completedFuture(expectedOrder)
+
+        // when
+        val result = exchangeService.cancelOrder(orderId).get()
+
+        // then
+        assertNotNull(result)
+        assertEquals(OrderState.CANCEL, result.state)
+        verify { exchangeProvider.cancelOrder(orderId) }
+    }
+
+    @Test
+    fun `getOrderStatus should delegate to provider`() {
+        // given
+        val orderId = "order-123"
+        val expectedOrder = OrderResult(
+            orderId = orderId,
+            market = "KRW-BTC",
+            side = OrderSide.BID,
+            orderType = OrderType.LIMIT,
+            price = BigDecimal("50000000"),
+            volume = BigDecimal("0.1"),
+            executedVolume = BigDecimal("0.1"),
+            remainingVolume = BigDecimal.ZERO,
+            state = OrderState.DONE,
+            createdAt = LocalDateTime.now()
+        )
+
+        every { exchangeProvider.getOrder(orderId) } returns CompletableFuture.completedFuture(expectedOrder)
+
+        // when
+        val result = exchangeService.getOrderStatus(orderId).get()
+
+        // then
+        assertNotNull(result)
+        assertEquals(OrderState.DONE, result.state)
+        verify { exchangeProvider.getOrder(orderId) }
+    }
+}

--- a/src/test/kotlin/me/onetwo/aiautotrade/infrastructure/llm/PromptTemplateServiceImplTest.kt
+++ b/src/test/kotlin/me/onetwo/aiautotrade/infrastructure/llm/PromptTemplateServiceImplTest.kt
@@ -38,7 +38,7 @@ class PromptTemplateServiceImplTest {
 
         // Then
         assertNotNull(prompt)
-        assertContains(prompt, "주식 자동매매 전문 AI 분석가")
+        assertContains(prompt, "자동매매 전문 AI 분석가")
         assertContains(prompt, "currentPrice: 50000")
         assertContains(prompt, "rsi: 45.5")
         assertContains(prompt, "긍정적인 실적 발표")
@@ -59,7 +59,7 @@ class PromptTemplateServiceImplTest {
 
         // Then
         assertNotNull(prompt)
-        assertContains(prompt, "주식 자동매매 전문 AI 분석가")
+        assertContains(prompt, "자동매매 전문 AI 분석가")
         // 뉴스 섹션이 포함되지 않았는지 확인
         assertTrue(prompt.contains("## 시장 데이터"), "Prompt should contain market data section")
         assertTrue(prompt.contains("## 기술적 지표"), "Prompt should contain technical indicators section")
@@ -84,7 +84,7 @@ class PromptTemplateServiceImplTest {
 
         // Then
         assertNotNull(prompt)
-        assertContains(prompt, "주식 시장 분석 전문가")
+        assertContains(prompt, "시장 분석 전문가")
         assertContains(prompt, "005930")
         assertContains(prompt, "1D")
         assertContains(prompt, "openPrice: 70000")
@@ -114,7 +114,7 @@ class PromptTemplateServiceImplTest {
 
         // Then
         assertNotNull(prompt)
-        assertContains(prompt, "주식 리스크 관리 전문가")
+        assertContains(prompt, "리스크 관리 전문가")
         assertContains(prompt, "AAPL")
         assertContains(prompt, "quantity: 100")
         assertContains(prompt, "volatility: HIGH")

--- a/src/test/kotlin/me/onetwo/aiautotrade/infrastructure/security/AesEncryptionServiceTest.kt
+++ b/src/test/kotlin/me/onetwo/aiautotrade/infrastructure/security/AesEncryptionServiceTest.kt
@@ -1,0 +1,107 @@
+package me.onetwo.aiautotrade.infrastructure.security
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AesEncryptionServiceTest {
+
+    private lateinit var encryptionService: AesEncryptionService
+
+    @BeforeEach
+    fun setUp() {
+        val encryptionKey = "0123456789abcdef0123456789abcdef" // 32 characters
+        val initVector = "fedcba9876543210" // 16 characters
+        encryptionService = AesEncryptionService(encryptionKey, initVector)
+    }
+
+    @Test
+    fun `encrypt should return different string from plain text`() {
+        // given
+        val plainText = "my-secret-api-key"
+
+        // when
+        val encrypted = encryptionService.encrypt(plainText)
+
+        // then
+        assertNotEquals(plainText, encrypted)
+        assertTrue(encrypted.isNotEmpty())
+    }
+
+    @Test
+    fun `decrypt should return original plain text`() {
+        // given
+        val plainText = "my-secret-api-key"
+        val encrypted = encryptionService.encrypt(plainText)
+
+        // when
+        val decrypted = encryptionService.decrypt(encrypted)
+
+        // then
+        assertEquals(plainText, decrypted)
+    }
+
+    @Test
+    fun `encrypt and decrypt should work for long strings`() {
+        // given
+        val plainText = "a".repeat(1000)
+
+        // when
+        val encrypted = encryptionService.encrypt(plainText)
+        val decrypted = encryptionService.decrypt(encrypted)
+
+        // then
+        assertEquals(plainText, decrypted)
+    }
+
+    @Test
+    fun `encrypt and decrypt should work for special characters`() {
+        // given
+        val plainText = "!@#$%^&*()_+-=[]{}|;':\",./<>?"
+
+        // when
+        val encrypted = encryptionService.encrypt(plainText)
+        val decrypted = encryptionService.decrypt(encrypted)
+
+        // then
+        assertEquals(plainText, decrypted)
+    }
+
+    @Test
+    fun `same plain text should produce same encrypted text`() {
+        // given
+        val plainText = "my-secret-api-key"
+
+        // when
+        val encrypted1 = encryptionService.encrypt(plainText)
+        val encrypted2 = encryptionService.encrypt(plainText)
+
+        // then
+        assertEquals(encrypted1, encrypted2)
+    }
+
+    @Test
+    fun `should throw exception for invalid encryption key length`() {
+        // given
+        val invalidKey = "short-key"
+        val validIv = "fedcba9876543210"
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            AesEncryptionService(invalidKey, validIv)
+        }
+    }
+
+    @Test
+    fun `should throw exception for invalid initialization vector length`() {
+        // given
+        val validKey = "0123456789abcdef0123456789abcdef"
+        val invalidIv = "short"
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            AesEncryptionService(validKey, invalidIv)
+        }
+    }
+}


### PR DESCRIPTION
### 작업 내용
업비트 거래소 API 연동 및 계정 관리 기능을 구현했습니다. Provider 패턴을 적용하여 다른 거래소로 쉽게 교체할 수 있도록 설계했으며, API 키 암호화 저장 기능을 포함합니다.

---

### 관련 이슈
Closes #1 
Closes #8 
Closes #9 
Closes #7 

---

## Changes
  ### 1. Exchange Provider 패턴 구현
  - `ExchangeProvider` 인터페이스로 거래소 추상화
  - `ExchangeService` 인터페이스로 비즈니스 로직 계층 분리
  - `DefaultExchangeService` 구현체로 주문 타입 자동 결정 로직 포함

  ### 2. 업비트 API 연동
  - `UpbitApiClient`: REST API 클라이언트 (JWT 인증 포함)
  - `UpbitExchangeProvider`: 업비트 구현체
  - 계좌 조회, 시세 조회, 주문 실행/취소/조회 기능 구현
  - WebFlux를 사용한 비동기 HTTP 통신

  ### 3. API 키 암호화 저장
  - `AesEncryptionService`: AES-256-CBC 암호화
  - `ApiKeyService`: API 키 관리 서비스
  - 암호화된 상태로 저장, 조회 시 자동 복호화
  - 현재는 메모리 저장소 사용 (추후 DB 연동 가능)

  ### 4. 공통 DTO 및 Enum
  - `AccountInfo`, `Balance`: 계좌 정보
  - `OrderRequest`, `OrderResult`: 주문 정보
  - `MarketPrice`: 시세 정보
  - `OrderSide`, `OrderType`, `OrderState`: 주문 관련 Enum

  ### 5. 의존성 추가
  - JWT: `io.jsonwebtoken:jjwt-api:0.12.3`
  - WebFlux: `spring-boot-starter-webflux`

  ## Test Plan
  - [x] 암호화 서비스 단위 테스트 (7개 테스트)
  - [x] API 키 서비스 단위 테스트 (8개 테스트)
  - [x] Exchange 서비스 단위 테스트 (8개 테스트)
  - [x] 빌드 성공 및 모든 테스트 통과

  ## Notes
  - Provider 패턴으로 바이낸스, 빗썸 등 다른 거래소 추가가 용이
  - 암호화 키는 application.yml에서 설정 가능
  - API 키는 현재 메모리에 저장되며, 추후 DB로 이관 예정
  - CompletableFuture 기반 비동기 처리로 성능 최적화
